### PR TITLE
Fix calcHeight variable

### DIFF
--- a/preview-bar/js/main.js
+++ b/preview-bar/js/main.js
@@ -126,7 +126,7 @@
   /**
    * Calculate height of the iframe, depending on the viewportState
    */
-  var calcHeight = function() {
+  window.calcHeight = function() {
     var previewBar = document.getElementById( 'custom-preview-bar' ),
       previewFrame = document.getElementById( 'main-preview-frame' );
 
@@ -200,7 +200,7 @@
 
   // events
   utils.ready(init);
-  window.addEventListener( 'load', calcHeight ); // calc height of the iframe on load
+  calcHeight(); // calc height of the iframe on load
   window.addEventListener( 'resize', calcHeight ); // calc height of the iframe on resize
 
 


### PR DESCRIPTION
For some reason, event listener doesn't work properly when loading the screen. If you have a theme that has a preloader, it is not positioned properly. I've noticed in the previous code that you are using variable which is on the scope of the context only. Therefore, I've added an easy fix so that iframe is calculated right away and not on load event listener. I've modified calcHeight variable into a global variable to fix the issue. Here's the error screenshot:

![preloader-issue](https://cloud.githubusercontent.com/assets/20467569/19011595/de148d06-87cd-11e6-8d29-b6e5ac4ca206.jpg)
