### PR TITLE
Fix for iframe height calculation when page is initialized

### DIFF
--- a/index.php
+++ b/index.php
@@ -138,6 +138,18 @@ if( key_exists( @$_GET['theme'], $items ) ) {
 				 * Dynamically create the iframe with the proper linker for analytics
 				 */
 				var linker;
+				
+				function defcalcHeight() {
+					var previewBar = document.getElementById( 'custom-preview-bar' ),
+					  previewFrame = document.getElementById( 'main-preview-frame' );
+
+					if ( previewFrame && previewBar ) {
+					  var possibleMaxHeight = window.innerHeight - previewBar.offsetHeight;
+					  previewFrame.style.height = possibleMaxHeight + 'px';	
+					}
+
+					document.body.style.minHeight = window.innerHeight + 'px';
+				}
 
 				function addiFrame( divId, url, opt_hash ) {
 					return function( tracker ) {
@@ -147,7 +159,7 @@ if( key_exists( @$_GET['theme'], $items ) ) {
 						iFrame.id     = 'main-preview-frame';
 						iFrame.setAttribute( 'frameborder', '0' );
 						document.getElementById( divId ).appendChild( iFrame );
-						calcHeight();
+						defcalcHeight();
 					};
 				}
 

--- a/preview-bar/js/main.js
+++ b/preview-bar/js/main.js
@@ -200,9 +200,7 @@
 
   // events
   utils.ready(init);
-  window.addEventListener( 'load', calcHeight ); // calc height of the iframe on load
   window.addEventListener( 'resize', calcHeight ); // calc height of the iframe on resize
-
 
   /**
    * UTM decorator - for tracking purposes


### PR DESCRIPTION
As I have observed, even if you put calcHeight on the init function, it doesn't work. If it is added on addEventListener on load, calcHeight is not loaded right away on which if you have themes that has a preloader, it behaves oddly. This fixes the issue because calcHeight cannot execute on this context unless it is converted to a global variable which should be avoided. Therefore, a new function is created on inline script where the iframe is created/loaded.
